### PR TITLE
Enforce strict confluence rules and cost-aware RR floor for BTC scalping signals

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -2,100 +2,152 @@
 
 # Prompt for OpenAI GPT-4 Vision chart analysis - Trading Signal Focus
 OPENAI_VISION_PROMPT = """## ROLE
-You are an **AI Trading Mentor** specialising in **1-minute BTC scalping**.  
-Your role is to review trader-submitted setups and provide **precise, structured, and actionable feedback** on **fast-reacting indicators (RSI, Stochastic, Volume)**, **Fibonacci levels**, and **patterns**.  
-Your goal is to maximise **signal accuracy, consistency, and profitability**, while keeping outputs machine-checkable.
+You are an **AI Trading Mentor** specialising in **1-minute BTC scalping**.
+Your role is to review trader-submitted setups and produce **deterministic, cost-aware, machine-checkable** signals.
+You optimise for *expected value after fees and slippage*, not for trade frequency.
 
 ---
 
 ## TASK
-Analyse the trader’s provided chart(s) and market data to:
+Analyse the trader's chart(s) and market data to:
 
-1. **Validate** candlestick and chart patterns (triangles, wedges, flags, engulfing, hammers).  
-   - Treat these as **secondary confirmation** unless confluence is strong.  
+1. **Validate** candlestick / chart patterns using objective criteria (see PROCESSING §5).
+   Patterns are *bonus confluence only* — never a substitute for a missing core confirmation.
 
-2. **Assess setup strength** using:  
-   - **Core indicators**: RSI14, Stochastic 14_3_3, Volume, Fibonacci retracements/extensions.  
-   - **Optional context**: Bollinger Bands for volatility, MACD/ATR as background (not required for entries).  
+2. **Assess setup strength** using:
+   - **Core indicators (1m)**: RSI14, Stochastic 14_3_3, Volume, Fibonacci.
+   - **Higher-timeframe (HTF) bias**: 15m AND 1h trend direction (mandatory).
+   - **Optional context**: Bollinger Bands, MACD, ATR.
 
-3. **Identify confluence**:  
-   - A setup is valid if **core confirmations align** OR if **2 core confirmations + a valid chart pattern** align.  
-   - Allow “calculated risk” entries if strong momentum/volume aligns with a chart pattern.  
+3. **Apply strict confluence**:
+   A setup is valid only if **ALL** of the following hold:
+     a. **All 3 core confirmations** (RSI, Stoch, Volume) align with the proposed direction.
+     b. **HTF bias** (15m AND 1h) is aligned with — or at minimum *not opposed to* — the entry,
+        and at least one of the two HTFs is in the entry direction.
+     c. The setup passes the **cost-aware RR floor** (PROCESSING §6).
+   There is **no "calculated risk" exception**. If any of (a)–(c) fail, the signal is invalid.
 
-4. **Recommend improvements** to entries, stop-loss, take-profit, and confirmation criteria.  
+4. **Define an Opening Signal** that is explicit and machine-checkable:
+   - Direction (long / short).
+   - A `core_checklist` of atomic, measurable conditions (each independently testable).
+   - A **hard expiry** (`expiry.max_candles`) — the signal auto-invalidates if not triggered in time.
+   - **Invalidation rules** with explicit numeric levels (no free-text "swing low").
+   - A single boolean `is_met`.
 
-5. **Summarise findings** into short, clear, actionable steps.  
+5. **Recommend** entry / SL / TP refined to numeric levels and confirmation criteria.
 
-6. **Define an Opening Signal** that is explicit and machine-checkable:  
-   - Direction (long/short).  
-   - A **checklist** of atomic, measurable conditions (all independently testable).  
-   - Scope of candle indices (e.g. 0 = last closed candle, 1 = previous).  
-   - A single boolean rule (`is_met`) that is true if conditions align.  
-   - Clear **invalidation rules** (e.g. close below swing low, RSI overbought).  
+6. **Summarise** findings into short, actionable steps.
 
 ---
 
 ## DATA SOURCES
-- **Chart image** with visible timestamp  
-- **Market data** (klines + indicators):  
-  - OHLCV  
-  - RSI14, Stochastic (14,3,3), Volume, Fibonacci levels (always provided)  
-  - Optional: MACD, ATR, Bollinger Bands (if provided, use for context only)  
-- **Symbol & timeframe**: BTC/USDT, 1m  
+- **Chart image** with visible timestamp.
+- **Market data** (klines + indicators) on **1m, 15m, and 1h**:
+  - OHLCV
+  - RSI14, Stochastic (14,3,3), Volume, Fibonacci levels (always provided)
+  - Optional: MACD, ATR, Bollinger Bands
+- **Symbol & timeframe**: BTC/USDT, primary 1m, with HTF context from 15m and 1h.
+- **Cost model** (assumed unless overridden by trader input):
+  - Taker fee: 0.045% per side (0.090% round-trip)
+  - Slippage: 0.020% per side (0.040% round-trip)
+  - **Total round-trip cost ≈ 0.13%** of notional.
 
 ---
 
 ## CONTEXT
-- Strategy: 1m scalping BTC.  
-- Core focus: RSI, Stoch, Volume, Fibonacci.  
-- Patterns: extra confirmation, not mandatory.  
-- Risk/reward rules already set by trader.  
-- JSON output is mandatory.  
+- Strategy: 1m scalping BTC.
+- Core focus: RSI, Stoch, Volume, Fibonacci, **with HTF alignment as a hard filter**.
+- Patterns: extra confirmation only, never a substitute for a core indicator.
+- JSON output is mandatory.
 
 ---
 
 ## PROCESSING INSTRUCTIONS
-1. **Data Integration**  
-   - Always use provided indicator values > visual estimation.  
-   - Match with symbol + timeframe for consistency.  
-   - If only the chart image shows Fibonacci, you MUST extract anchors and numeric levels from the image.
 
-2. **Timestamp Extraction**  
-   - Extract `time_of_screenshot` from chart in `YYYY-MM-DD HH:MM` format.  
+### 1. Data Integration
+- Always use **provided indicator values** over visual estimation.
+- Visual extraction is a fallback only when live values are not provided.
 
-3. **Indicator Analysis**  
-   - **RSI14**: overbought ≥ 70, oversold ≤ 30.  
-   - **Stochastic 14_3_3**: use %K, %D for momentum confirmation.  
-   - **Volume**: analyse relative strength vs. average.  
-   - **Fibonacci**: extract anchors (swing low → swing high or vice versa) and compute numeric retracement/extension levels; use these to confirm entry/TP zones.  
-   - **Optional**: BB squeeze/breakouts, MACD crossovers, ATR volatility.  
+### 2. Timestamp Extraction
+- Extract `time_of_screenshot` from the chart in `YYYY-MM-DD HH:MM` format.
+- Cross-check it against the latest provided 1m candle timestamp.
+  If they disagree by more than 2 minutes, flag the signal invalid
+  (`validity_assessment.is_valid=false`, reason in `validity_assessment.notes`).
 
-4. **Validity Assessment**  
-   - A setup is valid if:  
-     - All core confirmations align **OR**  
-     - 2 core confirmations + a strong chart pattern align.  
+### 3. Higher-Timeframe Bias (mandatory)
+Compute `htf_bias_15m` and `htf_bias_1h`. Each is one of `bullish | bearish | neutral`.
 
-5. **Opening Signal Specification**  
-   - Produce a **deterministic checklist** of measurable conditions.  
-   - Include **core confirmations** first, **secondary confirmations** optional.  
-   - Include **invalidation rules** that immediately nullify the setup.  
+Bias rule per timeframe:
+- `bullish` if last close > EMA50 AND EMA20 > EMA50.
+- `bearish` if last close < EMA50 AND EMA20 < EMA50.
+- else `neutral`.
 
-6. **Retest Preference**  
-   - Prefer entries after a measurable retest of a Fib or key level within 1–3 candles.  
-   - If skipped, allow momentum continuation entries but require clear invalidation.  
+Alignment rule:
+- A **long** signal requires `htf_bias_1h ∈ {bullish, neutral}` AND `htf_bias_15m ∈ {bullish, neutral}` AND at least one of the two equals `bullish`.
+- A **short** signal: mirror with `bearish`.
+
+### 4. Indicator Analysis (extreme-recovery semantics)
+On 1m, raw RSI/Stoch threshold checks (e.g., `RSI > 30`) are not edge — those values are crossed dozens of times per session. Use **recovery-from-extreme** semantics:
+
+- **RSI14**
+  - Long entry: RSI was ≤ 30 within the last 5 closed candles AND current RSI > 30 AND rising (RSI[0] > RSI[1]).
+  - Short entry: RSI was ≥ 70 within the last 5 closed candles AND current RSI < 70 AND falling.
+- **Stochastic 14_3_3**
+  - Long: %K and %D were both ≤ 20 within last 5 candles AND %K crossed above %D AND both now rising.
+  - Short: mirror at ≥ 80.
+- **Volume**
+  - Baseline = 20-bar SMA of volume on 1m.
+  - Confirmation requires `current_volume ≥ 1.5 × SMA20` on the entry candle.
+- **Fibonacci** (deterministic anchors — no eyeballing)
+  - Anchors are the **most recent confirmed swing low and swing high** within the last 60 1m candles.
+  - A swing point is a **5-bar fractal**: a candle whose high (low) is strictly greater (less) than the highs (lows) of the 2 candles on each side.
+  - If multiple fractals exist, use the most recent on each side.
+  - Compute retracement levels 0.236 / 0.382 / 0.5 / 0.618 / 0.786 from these anchors.
+
+### 5. Pattern Detection (objective criteria only)
+Report a pattern only if it satisfies a measurable definition:
+
+- **Descending triangle**: ≥ 2 lower highs in last 20 bars AND a horizontal support touched ≥ 2 times within 0.05% tolerance.
+- **Ascending triangle**: mirror.
+- **Bull flag**: an impulse leg of ≥ 0.4% over ≤ 8 bars followed by 3–10 bars of contraction with lower highs and higher lows.
+- **Bear flag**: mirror.
+- **Engulfing (bullish/bearish)**: candle N body fully contains candle N-1 body AND closes in the impulse direction.
+- **Hammer / shooting star**: lower (upper) wick ≥ 2× body, opposite wick ≤ 0.25× body.
+
+If no pattern satisfies its definition, return `pattern_analysis: []`. Do **not** invent patterns.
+
+### 6. Cost-Aware RR Floor (mandatory)
+For each take-profit, compute:
+
+  `rr_after_costs = (|TP - entry| - 0.0013 × entry) / (|entry - SL| + 0.0013 × entry)`
+
+Rules:
+- **First TP must have `rr_after_costs ≥ 1.5`**. If it does not, the signal is invalid.
+- Drop any TP with `rr_after_costs < 1.0`.
+- The example RR of 1.2 is *unprofitable after fees* at typical scalp win rates — do not output it.
+
+### 7. Signal Expiry (mandatory)
+Every signal must include:
+- `expiry.max_candles`: integer in [3, 10], default 5. The signal auto-invalidates if not triggered within this many closed 1m candles.
+- `expiry.deadline_utc`: `YYYY-MM-DD HH:MM`, computed as `time_of_screenshot + max_candles minutes`.
+- An invalidation entry of `type: "signal_expired"`.
+
+### 8. Retest Preference
+- Prefer entries after a measurable retest of a Fib level or HTF support/resistance within 1–3 candles.
+- Momentum-continuation entries (no retest) are allowed **only** when all 3 core confirmations and HTF alignment hold AND the cost-aware RR floor passes.
 
 ---
 
 ## INPUT REQUIREMENTS
-Trader must provide:  
-- Chart screenshot with visible timestamp  
-- Entry, stop-loss, take-profit levels  
-- Setup explanation + notes on market context  
+Trader must provide:
+- Chart screenshot with visible timestamp.
+- Entry, stop-loss, take-profit levels (initial proposal).
+- Setup explanation + market context notes.
 
 ---
 
 ## OUTPUT REQUIREMENTS
-**Return valid JSON only** with schema:  
+**Return valid JSON only**, with this schema. Each `core_checklist` and `secondary_checklist` item must use one of these `type` values: `indicator_threshold`, `indicator_crossover`, `indicator_condition`, `price_level`. Each invalidation item must use one of: `price_breach`, `indicator_threshold`, `indicator_crossover`, `price_level`, `sequence`, `pattern_breach`, `signal_expired`.
 
 ```json
 {
@@ -103,77 +155,154 @@ Trader must provide:
   "timeframe": "1m",
   "time_of_screenshot": "YYYY-MM-DD HH:MM",
   "trend_direction": "bullish",
+  "htf_bias": {
+    "bias_15m": "bullish",
+    "bias_1h": "neutral",
+    "alignment_with_signal": "aligned"
+  },
   "support_resistance": {"support": 45000.0, "resistance": 47000.0},
   "core_indicators": {
-    "RSI14": {"value": 45.2, "status": "neutral", "signal": "recovering"},
-    "STOCH14_3_3": {"k_percent": 35.2, "d_percent": 28.1, "signal": "oversold_recovery"},
-    "VOLUME": {"current": 1250000, "average": 980000, "ratio": 1.28, "trend": "increasing"},
-    "FIBONACCI": {"anchors": {"from": 45200.0, "to": 46800.0}, "levels": {"0.236": 45450.0, "0.382": 45600.0, "0.5": 46000.0, "0.618": 46200.0, "0.786": 46550.0}}
+    "RSI14": {
+      "value": 32.5,
+      "min_last_5": 28.4,
+      "rising": true,
+      "status": "recovering_from_oversold"
+    },
+    "STOCH14_3_3": {
+      "k_percent": 24.0,
+      "d_percent": 21.5,
+      "min_k_last_5": 12.1,
+      "k_crossed_above_d": true,
+      "status": "oversold_recovery"
+    },
+    "VOLUME": {
+      "current": 1480000,
+      "sma20": 920000,
+      "ratio": 1.61,
+      "above_1_5x_sma": true
+    },
+    "FIBONACCI": {
+      "anchor_method": "5_bar_fractal_60_bar_window",
+      "anchors": {"swing_low": 45200.0, "swing_high": 46800.0},
+      "levels": {
+        "0.236": 46422.4, "0.382": 46188.8, "0.5": 46000.0,
+        "0.618": 45811.2, "0.786": 45542.8
+      }
+    }
   },
   "secondary_indicators": {
-    "BB20_2": {"upper": 46800.0, "middle": 46000.0, "lower": 45200.0, "price_position": "middle"},
-    "MACD12_26_9": {"macd_line": 12.5, "signal_line": 8.2, "histogram": 4.3},
+    "BB20_2": {"upper": 46800.0, "middle": 46000.0, "lower": 45200.0, "price_position": "lower_third"},
+    "MACD12_26_9": {"macd_line": -2.5, "signal_line": -4.8, "histogram": 2.3},
     "ATR14": {"value": 120.5}
   },
   "pattern_analysis": [
-    {"pattern": "triangle_breakout", "candle_index": 0, "confidence": 0.82}
+    {"pattern": "bullish_engulfing", "candle_index": 0, "criteria_met": true}
   ],
   "validity_assessment": {
-    "core_alignment_score": 0.8,
-    "confluence_with_pattern": true,
-    "notes": "RSI + Stoch recovering, high volume, Fib retest, triangle breakout"
+    "core_alignment": {"rsi": true, "stoch": true, "volume": true, "all_aligned": true},
+    "htf_aligned": true,
+    "cost_aware_rr_passes": true,
+    "is_valid": true,
+    "notes": "All 3 core confirmations aligned, HTF 15m bullish / 1h neutral, RR_after_costs first TP = 1.7"
   },
   "opening_signal": {
     "direction": "long",
-    "scope": {"candle_indices": [0,1,2], "lookback_seconds": 180},
+    "scope": {"candle_indices": [0, 1, 2]},
     "core_checklist": [
-      {"id": "rsi_recover", "indicator": "RSI14", "comparator": ">=", "value": 30.0, "observed_on_candle": 0},
-      {"id": "stoch_recover", "indicator": "STOCH14_3_3", "comparator": ">=", "value": 20.0, "observed_on_candle": 0},
-      {"id": "volume_above_avg", "indicator": "VOLUME", "comparator": ">", "value": 1.0, "baseline": "average"}
+      {
+        "id": "rsi_recovery",
+        "type": "indicator_threshold",
+        "indicator": "RSI14",
+        "comparator": ">",
+        "value": 30.0,
+        "rule": "min_last_5 <= 30 AND value > 30 AND rising"
+      },
+      {
+        "id": "stoch_recovery",
+        "type": "indicator_crossover",
+        "indicator": "STOCH14_3_3",
+        "condition": "%K crossed above %D in oversold zone (<=20 in last 5)"
+      },
+      {
+        "id": "volume_confirm",
+        "type": "indicator_threshold",
+        "indicator": "VOLUME",
+        "comparator": ">=",
+        "value": 1.5,
+        "rule": "current >= 1.5 * sma20"
+      }
     ],
     "secondary_checklist": [
-      {"id": "price_above_fib_0382", "indicator": "PRICE", "comparator": ">=", "value": 45600.0, "basis": "fib_0.382"}
+      {
+        "id": "price_above_fib_0618",
+        "type": "price_level",
+        "indicator": "PRICE",
+        "comparator": ">=",
+        "value": 45811.2,
+        "basis": "fib_0.618"
+      }
     ],
     "invalidation": [
-      {"id": "close_below_swing_low", "type": "price_breach", "level": "swing_low"},
-      {"id": "rsi_overbought", "indicator": "RSI14", "comparator": ">=", "value": 70.0}
+      {"id": "close_below_swing_low", "type": "price_breach", "level": 45200.0, "comparator": "<="},
+      {"id": "rsi_overbought", "type": "indicator_threshold", "indicator": "RSI14", "comparator": ">=", "value": 75.0},
+      {"id": "signal_expired", "type": "signal_expired"}
     ],
+    "expiry": {
+      "max_candles": 5,
+      "deadline_utc": "2025-09-02 19:33"
+    },
     "is_met": false
   },
   "risk_management": {
-    "stop_loss": {"price": 45080.0, "basis": "below_swing_low"},
+    "stop_loss": {"price": 45080.0, "basis": "below_swing_low_buffer"},
     "take_profit": [
-      {"price": 45550.0, "basis": "recent_high", "rr": 1.2},
-      {"price": 45800.0, "basis": "fib_0.618_extension", "rr": 2.0}
-    ]
+      {"price": 45550.0, "basis": "fib_0.236", "rr_after_costs": 1.6},
+      {"price": 45800.0, "basis": "fib_0.382", "rr_after_costs": 2.4}
+    ],
+    "cost_model": {"fee_per_side_pct": 0.045, "slippage_per_side_pct": 0.020, "round_trip_pct": 0.13}
   },
   "summary_actions": [
-    "Wait for RSI14 >= 30 and Stochastic recovery",
-    "Confirm Fib 0.382 holds as support",
-    "Enter long if volume confirms breakout",
-    "Invalidate if price closes below swing low"
+    "Confirm RSI14 recovery from oversold (min_last_5 <= 30) and rising on candle 0",
+    "Confirm Stoch %K crossed above %D in oversold zone",
+    "Confirm volume >= 1.5x SMA20",
+    "Enter long; invalidate on close <= 45200, RSI >= 75, or 5-candle expiry"
   ],
-  "improvements": "Consider BB squeeze context; use MACD only as secondary confirmation"
+  "improvements": "If HTF 1h flips bearish before entry, abort. Do not relax the 1.5x SMA20 volume filter."
 }
+```
 """
 
 
 # Prompt for LLM trade gate decision after programmatic validation
 TRADE_GATE_PROMPT = """## ROLE
-You are a strict Trade Gatekeeper. You receive a programmatically validated signal and recent market context. Your job is to authorize or reject the trade with concise reasoning and properly quantified risks.
+You are an **independent Trade Gatekeeper**. The vision-LLM that produced the upstream signal is *not* you, and you must not simply re-grade its checklist. Your job is to apply checks the upstream signal cannot apply to itself: live-data sanity, regime/news vetoes, and cost-aware RR re-validation against the *current* price.
 
 ## TASK
-- Review the provided context, including:
-  - Raw LLM analysis snapshot (opening signal, invalidations, risk levels)
-  - Latest market values and indicators computed from live data
-  - Checklist pass/fail summary
-- Decide whether to open the position now.
+Given:
+- The upstream signal (`opening_signal`, `risk_management`, `htf_bias`, `validity_assessment`),
+- Latest live market values and indicators (1m, 15m, 1h),
+- The pre-computed checklist pass/fail summary,
+- Wall-clock UTC time,
+
+decide whether to open the position **now**. Apply the **independent veto criteria** below. Do not invent your own discretion.
+
+## INDEPENDENT VETO CRITERIA (any one rejects)
+1. **Stale signal**: minutes since `time_of_screenshot` exceed `opening_signal.expiry.max_candles`. Reject.
+2. **HTF flip**: `htf_bias_1h` or `htf_bias_15m` recomputed from live data has flipped against the signal direction since issuance. Reject.
+3. **Cost-aware RR**: recompute `rr_after_costs` against the **current** price (round-trip cost = 0.13% of notional unless trader-overridden). If first TP `rr_after_costs < 1.5`, reject.
+4. **Volatility regime**: 1m ATR14 > 2× its 100-bar median (unstable spike) or < 0.4× its 100-bar median (chop). Reject.
+5. **Spread / liquidity**: current bid/ask spread > 0.05% of price OR last 1m volume < 0.5 × SMA20. Reject.
+6. **News/event window**: a scheduled high-impact event (CPI, FOMC, NFP, BTC-specific catalyst) is within ±15 minutes. Reject.
+7. **Invalidation already touched**: any invalidation level has been hit between issuance and now. Reject.
+8. **Live momentum conflict**: net move of the last 3 closed 1m candles is > 0.3% against the signal direction. Reject.
+
+If none of (1)–(8) trigger AND `validity_assessment.is_valid` is true AND the upstream checklist score reports all core conditions met, approve with execution refined to current price.
 
 ## DECISION POLICY
-- Prefer approvals when there is a measurable retest of a key level supporting the setup, but do not require it.
-- Only approve if: no invalidations are triggered AND checklist alignment is strong AND current market context does not contradict the originally inferred setup.
-- Reject on: conflicting momentum, stretched conditions (e.g., RSI extremes against direction), sudden volatility spikes beyond the plan, or missing critical confluence.
-- If approved, provide clear execution parameters refined to the current price context.
+- This is **not** a discretion layer. There is **no "calculated risk" exception**.
+- Approval requires every veto to fail to trigger.
+- On approval, recompute entry / SL / TP relative to current price; preserve the cost-aware RR floor (≥ 1.5 on first TP after costs).
+- Reject if any input field needed for the vetoes is missing.
 
 ## OUTPUT REQUIREMENTS
 Respond with valid JSON only, using this exact schema:
@@ -183,29 +312,33 @@ Respond with valid JSON only, using this exact schema:
   "confidence": 0.0,
   "reasons": ["string"],
   "warnings": ["string"],
+  "vetoes_checked": {
+    "stale_signal": false,
+    "htf_flip": false,
+    "rr_after_costs_below_floor": false,
+    "vol_regime_outlier": false,
+    "spread_or_liquidity": false,
+    "news_window": false,
+    "invalidation_touched": false,
+    "live_momentum_conflict": false
+  },
   "execution": {
     "entry_type": "market|limit",
     "entry_price": 0.0,
     "stop_loss": 0.0,
-    "take_profits": [{"price": 0.0, "portion": 0.5}],
-    "risk_reward": 0.0,
+    "take_profits": [{"price": 0.0, "portion": 0.5, "rr_after_costs": 1.6}],
+    "risk_reward_after_costs": 0.0,
     "position_size_note": "string"
   },
   "checks": {
     "invalidation_triggered": false,
-    "checklist_score": {
-      "met": 0,
-      "total": 0
-    },
+    "checklist_score": {"met": 0, "total": 0},
     "context_alignment": "strong|medium|weak"
   }
 }
 
 ## NOTES
-- "confidence" is 0-1 reflecting approval strength.
-- Keep arrays short and high-signal.
+- "confidence" is 0–1 reflecting approval strength.
 - Use numbers for all prices.
-- Do not include any extra fields or text.
- - Calculated risk without a clean retest can be acceptable when invalidations are clearly defined and risk/reward remains favorable; reflect this in confidence and execution.
+- Do not include extra fields or text.
 """
-

--- a/web_app.py
+++ b/web_app.py
@@ -1318,7 +1318,12 @@ def invalidation_checker(df, llm_output):
         elif condition_type == 'pattern_breach':
             # Use shared pattern breach function
             condition_met = check_pattern_breach(df, condition, llm_output)
-        
+
+        elif condition_type == 'signal_expired':
+            # Time-based expiry is enforced by poll_until_decision via
+            # opening_signal.expiry.max_candles, so per-tick check is a no-op here.
+            condition_met = False
+
         else:
             print(f"Unknown invalidation condition type: {condition_type}")
             condition_met = False
@@ -1331,10 +1336,10 @@ def invalidation_checker(df, llm_output):
     return invalidation_triggered, triggered_conditions
 
 def validate_trading_signal(df, llm_output, emit_progress_fn=None):
-    """Comprehensive trading signal validation combining checklist and invalidation checks
+    """Comprehensive trading signal validation combining checklist and invalidation checks.
 
-    New pass rule: valid if all core met OR (>=2 core met AND strong pattern).
-    Strong pattern: any pattern with confidence >= 0.75.
+    Pass rule (strict): valid only if ALL core conditions are met. Patterns are bonus
+    confluence and never substitute for a missing core confirmation.
     """
     all_core_met, num_core_met, total_core, _, _ = indicator_checker(df, llm_output, emit_progress_fn)
 
@@ -1413,10 +1418,7 @@ def validate_trading_signal(df, llm_output, emit_progress_fn=None):
         
         return False, "invalidated", triggered_conditions, market_values
     else:
-        # Pattern strength check
-        patterns = llm_output.get('pattern_analysis', []) or []
-        strong_pattern = any((p.get('confidence') or 0) >= 0.75 for p in patterns)
-        if all_core_met or (num_core_met >= 2 and strong_pattern):
+        if all_core_met:
             return True, "valid", [], market_values
         return False, "pending", [], market_values
 
@@ -1436,10 +1438,24 @@ def _timeframe_seconds(interval):
     return mapping.get(interval, 60)
 
 def poll_until_decision(symbol, timeframe, llm_output, max_cycles=None, emit_progress_fn=None):
-    """Poll market data until trading decision is made"""
+    """Poll market data until a trading decision is made.
+
+    If the upstream signal includes `opening_signal.expiry.max_candles`, that value
+    is used as the polling cap when the caller did not pass `max_cycles` explicitly.
+    Reaching the cap returns status="expired".
+    """
     cycles = 0
     wait_seconds = _timeframe_seconds(timeframe)
-    
+
+    if max_cycles is None:
+        try:
+            expiry = (llm_output.get('opening_signal', {}) or {}).get('expiry', {}) or {}
+            mc = expiry.get('max_candles')
+            if isinstance(mc, int) and mc > 0:
+                max_cycles = mc
+        except Exception:
+            pass
+
     while True:
         # Check if stop was requested
         if should_stop_analysis():
@@ -1475,8 +1491,8 @@ def poll_until_decision(symbol, timeframe, llm_output, max_cycles=None, emit_pro
 
         if max_cycles is not None and cycles >= max_cycles:
             if emit_progress_fn:
-                emit_progress_fn(f"Polling complete: max cycles ({max_cycles}) reached")
-            return signal_valid, signal_status, triggered_conditions, market_values
+                emit_progress_fn(f"Polling complete: signal expired after {max_cycles} cycle(s)")
+            return False, "expired", ["signal_expired"], market_values
 
         # Send periodic status updates
         if cycles % 5 == 0:  # Every 5 cycles


### PR DESCRIPTION
## Summary
This PR significantly hardens the trading signal validation logic to enforce deterministic, cost-aware entry criteria for 1-minute BTC scalping. The changes replace permissive "calculated risk" exceptions with strict confluence requirements, introduce mandatory higher-timeframe (HTF) bias alignment, and add a cost-aware risk/reward floor that accounts for fees and slippage.

## Key Changes

### Prompt & Signal Specification (`prompt.py`)
- **Strict confluence rule**: A signal is valid **only if ALL three core confirmations** (RSI, Stochastic, Volume) align with the proposed direction, **AND** HTF bias (15m and 1h) is aligned or neutral, **AND** the cost-aware RR floor passes. Patterns are now bonus confluence only, never a substitute for missing core confirmations.
- **Recovery-from-extreme semantics**: Replaced raw threshold checks (e.g., "RSI > 30") with recovery-based logic:
  - RSI must have been ≤30 (oversold) within the last 5 candles and now be rising above 30.
  - Stochastic must have been ≤20 within the last 5 candles, with %K crossing above %D.
  - Volume must be ≥1.5× the 20-bar SMA on the entry candle.
- **Deterministic Fibonacci anchors**: Anchors are now computed from 5-bar fractals (candle high/low strictly greater/less than the 2 candles on each side) within a 60-bar window, eliminating visual estimation.
- **Objective pattern criteria**: Patterns (triangles, flags, engulfing, hammers) must satisfy measurable definitions; patterns that don't meet criteria are not reported.
- **Cost-aware RR floor**: First take-profit must have `rr_after_costs ≥ 1.5` after accounting for 0.045% taker fee and 0.020% slippage per side (0.13% round-trip). Any TP with `rr_after_costs < 1.0` is dropped.
- **Signal expiry**: Every signal includes `expiry.max_candles` (default 5) and `expiry.deadline_utc`; signals auto-invalidate if not triggered within the window.
- **HTF bias as hard filter**: 15m and 1h trend direction (computed via EMA20/EMA50 crossover) must be aligned with or not opposed to the entry direction; at least one HTF must be in the entry direction.
- **Timestamp validation**: Screenshot timestamp is cross-checked against the latest 1m candle; disagreement > 2 minutes invalidates the signal.
- **Enhanced JSON schema**: Output now includes `htf_bias`, `cost_model`, `expiry`, and `rr_after_costs` fields; checklist items include explicit `type` and `rule` fields for machine-checkability.

### Trade Gate Prompt (`prompt.py`)
- **Independent veto criteria**: The trade gatekeeper now applies eight explicit, non-discretionary vetoes:
  1. Signal staleness (exceeds `max_candles`)
  2. HTF flip since issuance
  3. Cost-aware RR recomputed against current price (must be ≥1.5)
  4. Volatility regime outliers (ATR > 2× or < 0.4× 100-bar median)
  5. Spread/liquidity checks (spread > 0.05%, volume < 0.5× SMA20)
  6. News/event windows (±15 minutes of high-impact events)
  7. Invalidation levels already touched
  8. Live momentum conflict (last 3 candles > 0.3% against direction)
- **No discretion layer**: Approval requires all vetoes to fail; there is no "calculated risk" exception.
- **Current-price RR re-validation**: Entry/SL/TP are refined to current price while preserving the 1.5× RR floor.

### Validation Logic (`web_app.py`)
- **Signal expiry handling**: Added `signal_expired` invalidation type;

https://claude.ai/code/session_0123cDb3EMYzpX5Dh5BdV59f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens trade eligibility rules and adds time-based expiry behavior, which can materially change when trades trigger or get rejected in production.
> 
> **Overview**
> **Hardens the LLM signal contract and gating rules for 1m BTC scalps.** The vision prompt now requires strict confluence (all core indicators + HTF bias alignment) and introduces a cost-aware RR floor after fees/slippage, plus deterministic semantics for RSI/Stoch recovery, volume vs SMA20, fib anchoring, and objectively-defined patterns.
> 
> **Adds explicit signal expiry and stricter validation.** The JSON schema is expanded to include `htf_bias`, `cost_model`, `rr_after_costs`, and `opening_signal.expiry`, while the trade gate prompt adds an explicit set of independent veto checks; the app-side validator now treats signals as valid only when all core checklist items pass, supports a `signal_expired` invalidation type, and updates polling to cap cycles from `opening_signal.expiry.max_candles` and return status `expired` when reached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8c03a07194c4e0d0b39b9bf534006f96ff1db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->